### PR TITLE
Fix: Add and Configure @babel/plugin-transform-runtime to resolve build failure

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,11 @@
+{
+  "presets": ["@babel/preset-env"],
+  "plugins": [
+    [
+      "@babel/plugin-transform-runtime",
+      {
+        "regenerator": true
+      }
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
     "build": "rollup -c",
     "start": "rollup -c -w",
     "format": "prettier src -w",
-    "prepare":"npm run build"
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.6",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-transform-runtime": "^7.9.6",
-    "@babel/preset-env": "^7.9.6",
+    "@babel/plugin-transform-runtime": "^7.28.0",
+    "@babel/preset-env": "^7.28.0",
     "@babel/preset-react": "^7.9.4",
     "@babel/runtime": "^7.9.6",
     "@rollup/plugin-babel": "^5.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,7 +34,8 @@ export default {
     json(),
     babel({
       exclude: 'node_modules/**',
-      babelHelpers: 'runtime'
+      babelHelpers: 'runtime',
+      plugins: ['@babel/plugin-transform-runtime']
     }),
   ]
 }


### PR DESCRIPTION
# Description

> when trying to install dependencies to build the frontend, I noticed that one of the dependencies had a build failure as shown in the attached screenshot.

<img width="1197" height="703" alt="Capture d’écran 2025-08-08 004412" src="https://github.com/user-attachments/assets/fa269b43-776a-4264-9106-0cec27abf99a" />


> I addressed this by adding the missing plugin and configuring it. Now, it installs and builds via Yarn with no issues, and this repository is safe and functional.

> ## after integrating the missing plugin

<img width="677" height="373" alt="image" src="https://github.com/user-attachments/assets/58efa461-e217-4853-996f-e6ba10194981" />
